### PR TITLE
fix font.h location

### DIFF
--- a/font/font.c
+++ b/font/font.c
@@ -1,6 +1,6 @@
 #include <stdio.h> 
 #include <gb/gb.h>
-#include <gb/font.h>
+#include <gbdk/font.h>
 
 void main() {
 	font_init(); // Initialize font


### PR DESCRIPTION
From update [4.0.5](https://github.com/gbdk-2020/gbdk-2020/releases/tag/4.0.5), the font header location is changed.

Running this script gives the import error: `fatal error: gb/font.h: No such file or directory`

Changing the folder from `gb` to `gbdk` fixes this.